### PR TITLE
Add all default cookies in README example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,5 +44,7 @@ project's settings module:
     COOKIEFILTER_ALLOWED = [
         "analytics",
         "csrftoken",
+        "django_language",
+        "messages",
         "sessionid",
     ]


### PR DESCRIPTION
Just to avoid bad copy/pasting assumptions - I'm adding the full list of cookies in the default README, so if anyone does customise it - it assumes that you're adding more to the standard Django cookies.