### PR TITLE
All the updates

### DIFF
--- a/.github/matrix.py
+++ b/.github/matrix.py
@@ -1,0 +1,32 @@
+import fileinput
+import json
+import re
+import sys
+
+PY_VERSIONS_RE = re.compile(r"^py(\d)(\d+)")
+
+
+def main():
+    actions_matrix = []
+
+    for tox_env in fileinput.input():
+        tox_env = tox_env.rstrip()
+
+        if python_match := PY_VERSIONS_RE.match(tox_env):
+            version_tuple = python_match.groups()
+        else:
+            version_tuple = sys.version_info[0:2]
+
+        python_version = "{}.{}".format(*version_tuple)
+        actions_matrix.append(
+            {
+                "python": python_version,
+                "tox_env": tox_env,
+            }
+        )
+
+    print(json.dumps(actions_matrix))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Python pip cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Python pip cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,78 +1,54 @@
 name: CI
 on: pull_request
 jobs:
-  check:
-    name: Check
+  matrix:
+    name: Build test matrix
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.8'
       - name: Python pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/testing.txt') }}
-      - name: Run check
+          key: ${{ runner.os }}-matrix-pip-${{ hashFiles('requirements/testing.txt') }}
+      - name: Run tox
+        id: matrix
         run: |
-          pip install tox
-          tox -e check
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.8'
-      - name: Python pip cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/testing.txt') }}
-      - name: Run lint
-        run: |
-          pip install tox
-          tox -e lint
+          pip install $(grep "^tox==" requirements/local.txt)
+          echo "::set-output name=tox_matrix::$(tox -l | fgrep -v coverage | python .github/matrix.py)"
+    outputs:
+      tox_matrix: ${{ steps.matrix.outputs.tox_matrix }}
 
   test:
-    name: Test -- Python ${{ matrix.python }} - Django ${{ matrix.django }}
+    name: Test -- ${{ matrix.tox_env }}
     runs-on: ubuntu-20.04
+    needs: matrix
     strategy:
       matrix:
-        python:
-          - '3.5'
-          - '3.6'
-          - '3.7'
-          - '3.8'
-        django:
-          - '1.11'
-          - '2.2'
-        exclude:
-          - python: '3.8'
-            django: '1.11'
+        include: ${{ fromJson(needs.matrix.outputs.tox_matrix) }}
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
       - name: Python pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-python${{ matrix.python }}-django${{ matrix.django }}-pip-${{ hashFiles('requirements/testing.txt') }}
+          key: ${{ runner.os }}-${{ matrix.tox_env }}-pip-${{ hashFiles('requirements/testing.txt') }}
       - name: Run tests
-        env:
-          PYTHON_VERSION: ${{ matrix.python }}
         run: |
-          pip install tox
-          tox -e py${PYTHON_VERSION//./}-django${{ matrix.django }}
+          pip install $(grep "^tox==" requirements/local.txt)
+          tox -e ${{ matrix.tox_env }}

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,9 +1,0 @@
-[isort]
-combine_as_imports = true
-sections = FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-known_django = django
-include_trailing_comma = false
-line_length = 99
-multi_line_output = 5
-not_skip = __init__.py
-skip_glob = */migrations/*.py

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019-2020, Developer Society Limited
+Copyright (c) 2019-2022, Developer Society Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Makefile
+++ b/Makefile
@@ -106,10 +106,10 @@ pip-install-local: venv-check
 
 # ISort
 isort-lint:
-	isort --recursive --check-only --diff cookiefilter tests
+	isort --check-only --diff cookiefilter tests
 
 isort-format:
-	isort --recursive cookiefilter tests
+	isort cookiefilter tests
 
 
 # Flake8

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ pipdeptree-check:
 
 # Project testing
 django-test:
-	coverage run $$(which django-admin) test --pythonpath $$(pwd) --settings tests.settings tests
+	PYTHONWARNINGS=all coverage run $$(which django-admin) test --pythonpath $$(pwd) --settings tests.settings tests
 
 
 # Help

--- a/Makefile
+++ b/Makefile
@@ -138,10 +138,10 @@ coverage-clean:
 
 # Black
 black-lint:
-	black --line-length 99 --target-version py35 --exclude '/migrations/' --check cookiefilter tests setup.py
+	black --check cookiefilter tests setup.py
 
 black-format:
-	black --line-length 99 --target-version py35 --exclude '/migrations/' cookiefilter tests setup.py
+	black cookiefilter tests setup.py
 
 
 #pipdeptree

--- a/README.rst
+++ b/README.rst
@@ -17,8 +17,7 @@ Using pip_:
 
     $ pip install django-cookiefilter
 
-Edit your Django project's settings module, and add the middleware to the start of  ``MIDDLEWARE``
-(or ``MIDDLEWARE_CLASSES`` for Django 1.8):
+Edit your Django project's settings module, and add the middleware to the start of ``MIDDLEWARE``:
 
 .. code-block:: python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+[tool.black]
+line-length = 99
+target-version = ['py35']
+exclude = '/migrations/'
+
 [tool.isort]
 combine_as_imports = true
 sections = ['FUTURE','STDLIB','DJANGO','THIRDPARTY','FIRSTPARTY','LOCALFOLDER']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.isort]
+combine_as_imports = true
+sections = ['FUTURE','STDLIB','DJANGO','THIRDPARTY','FIRSTPARTY','LOCALFOLDER']
+known_django = 'django'
+include_trailing_comma = true
+float_to_top = true
+force_grid_wrap = 0
+line_length = 99
+multi_line_output = 3
+skip_glob = '*/migrations/*.py'

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,6 +1,6 @@
 -r testing.txt
 
 bump2version==1.0.1
-Django>=2.2,<3.0
+Django>=3.2,<4.0
 tox==3.26.0
 twine==4.0.1

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -2,5 +2,5 @@
 
 bump2version==1.0.1
 Django>=2.2,<3.0
-tox==3.20.1
-twine==3.2.0
+tox==3.26.0
+twine==4.0.1

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,5 +1,5 @@
-black==22.3.0 ; python_version >= '3.6'
-coverage==5.3
-flake8==3.8.4
+black==22.8.0 ; python_version >= '3.6'
+coverage==5.5
+flake8==5.0.4 ; python_version >= '3.6'
 isort==4.3.21
-pipdeptree==2.2.0
+pipdeptree==2.3.1 ; python_version >= '3.7'

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,5 +1,5 @@
 black==22.8.0 ; python_version >= '3.6'
 coverage==5.5
 flake8==5.0.4 ; python_version >= '3.6'
-isort==4.3.21
+isort==5.10.1 ; python_version >= '3.6'
 pipdeptree==2.3.1 ; python_version >= '3.7'

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Framework :: Django",
         "Framework :: Django :: 1.11",
         "Framework :: Django :: 2.2",

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Framework :: Django",
         "Framework :: Django :: 1.11",
         "Framework :: Django :: 2.2",

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "Framework :: Django",
         "Framework :: Django :: 1.11",
         "Framework :: Django :: 2.2",
+        "Framework :: Django :: 3.2",
     ],
     license="BSD",
 )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,7 @@
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
 
+USE_TZ = True
+
 SECRET_KEY = "cookiefilter"
 
 INSTALLED_APPS = ["cookiefilter"]

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     lint
     {py35,py36,py37}-django1.11
     {py35,py36,py37,py38,py39}-django2.2
+    {py36,py37,py38,py39}-django3.2
     coverage
 skipsdist = true
 
@@ -12,6 +13,7 @@ deps =
     -rrequirements/testing.txt
     django1.11: Django>=1.11,<2.0
     django2.2: Django>=2.2,<3.0
+    django3.2: Django>=3.2,<4.0
 whitelist_externals = make
 commands = make test
 usedevelop = true

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     check
     lint
     {py35,py36,py37}-django1.11
-    {py35,py36,py37,py38}-django2.2
+    {py35,py36,py37,py38,py39}-django2.2
     coverage
 skipsdist = true
 
@@ -17,16 +17,16 @@ commands = make test
 usedevelop = true
 
 [testenv:check]
-basepython = python3.8
+basepython = python3.9
 commands = make check
 skip_install = true
 
 [testenv:lint]
-basepython = python3.8
+basepython = python3.9
 commands = make lint
 skip_install = true
 
 [testenv:coverage]
-basepython = python3.8
+basepython = python3.9
 commands = make coverage-report
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,6 @@ deps =
 whitelist_externals = make
 commands = make test
 usedevelop = true
-setenv =
-    PYTHONWARNINGS = all
 
 [testenv:check]
 basepython = python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     lint
     {py35,py36,py37}-django1.11
     {py35,py36,py37,py38,py39}-django2.2
-    {py36,py37,py38,py39}-django3.2
+    {py36,py37,py38,py39,py310}-django3.2
     coverage
 skipsdist = true
 
@@ -19,16 +19,16 @@ commands = make test
 usedevelop = true
 
 [testenv:check]
-basepython = python3.9
+basepython = python3.10
 commands = make check
 skip_install = true
 
 [testenv:lint]
-basepython = python3.9
+basepython = python3.10
 commands = make lint
 skip_install = true
 
 [testenv:coverage]
-basepython = python3.9
+basepython = python3.10
 commands = make coverage-report
 skip_install = true


### PR DESCRIPTION
Happy Hacktoberfest!

The setup for this package is a little bit dated, so it's time to bring it up to modern standards. Mostly just confirming support for newer versions of Django, improving CI, bumping up versions, etc.

I'm leaving Python 3.5/3.6 support in, but it's now getting a bit painful - so will probably drop them after we've got a release for Django 4.2 in April.