### PR TITLE
Bump version: 1.0 → 1.1

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "1.0"
+current_version = "1.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)(\\.(?P<patch>\\d+))?"
 serialize = [
     "{major}.{minor}.{patch}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'django-cookiefilter'
-version = '1.0'
+version = '1.1'
 description = 'Django Cookie Filter'
 readme = 'README.md'
 maintainers = [{ name = 'The Developer Society', email = 'studio@dev.ngo' }]


### PR DESCRIPTION
No significant changes since the last release, just version bumps and automating deploys with GitHub Actions.