### PR TITLE
Change COOKIEFILTER_ALLOWED to COOKIEFILTER_ALLOWED_NAMES

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ MIDDLEWARE = [
 ## Configuration
 
 Out of the box the standard Django cookie names will work without any other configuration. However
-if your project uses different or additional cookie names, edit ``COOKIEFILTER_ALLOWED`` in your
-project's settings module:
+if your project uses different or additional cookie names, edit ``COOKIEFILTER_ALLOWED_NAMES`` in
+your project's settings module:
 
 ```python
-COOKIEFILTER_ALLOWED = [
+COOKIEFILTER_ALLOWED_NAMES = [
     "analytics",
     "csrftoken",
     "django_language",
@@ -39,3 +39,7 @@ COOKIEFILTER_ALLOWED = [
     "sessionid",
 ]
 ```
+
+> [!NOTE]
+> This setting was previously named ``COOKIEFILTER_ALLOWED``, which is now deprecated and will be
+> removed in a future version.

--- a/cookiefilter/middleware.py
+++ b/cookiefilter/middleware.py
@@ -1,8 +1,11 @@
 import logging
+import warnings
+from functools import lru_cache
 from http.cookies import SimpleCookie
 
 from django.conf import settings
 from django.contrib.messages.storage.cookie import CookieStorage
+from django.utils.functional import classproperty
 
 logger = logging.getLogger(__name__)
 
@@ -15,18 +18,25 @@ class CookieFilterMiddleware:
     Django project settings, or by extending this class.
     """
 
-    allowed_cookies = frozenset(
-        getattr(
-            settings,
-            "COOKIEFILTER_ALLOWED",
-            [
-                settings.CSRF_COOKIE_NAME,
-                settings.LANGUAGE_COOKIE_NAME,
-                settings.SESSION_COOKIE_NAME,
-                CookieStorage.cookie_name,
-            ],
-        )
-    )
+    @classproperty
+    @lru_cache(maxsize=1)
+    def allowed_cookies(cls):
+        default_cookies = [
+            settings.CSRF_COOKIE_NAME,
+            settings.LANGUAGE_COOKIE_NAME,
+            settings.SESSION_COOKIE_NAME,
+            CookieStorage.cookie_name,
+        ]
+
+        if hasattr(settings, "COOKIEFILTER_ALLOWED"):
+            warnings.warn(
+                "COOKIEFILTER_ALLOWED is deprecated, use COOKIEFILTER_ALLOWED_NAMES instead",
+                DeprecationWarning,
+                stacklevel=1,
+            )
+            return frozenset(settings.COOKIEFILTER_ALLOWED)
+
+        return frozenset(getattr(settings, "COOKIEFILTER_ALLOWED_NAMES", default_cookies))
 
     def __init__(self, get_response):
         self.get_response = get_response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,4 +119,7 @@ section-order = [
 'django' = ['django']
 
 [tool.ruff.lint.pep8-naming]
+classmethod-decorators = [
+  'django.utils.functional.classproperty',
+]
 extend-ignore-names = ['assert*']

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,5 +1,7 @@
+import warnings
+
 from django.http import HttpResponse
-from django.test import RequestFactory, SimpleTestCase
+from django.test import RequestFactory, SimpleTestCase, override_settings
 
 from cookiefilter.middleware import CookieFilterMiddleware
 
@@ -10,6 +12,44 @@ def get_response(request):
 
 
 class TestCookieFilterMiddleware(SimpleTestCase):
+    def setUp(self):
+        # Ensure lru_cache is cleared before each run
+        CookieFilterMiddleware.__dict__["allowed_cookies"].fget.cache_clear()
+
+    def test_default_allowed_cookies(self):
+        middleware = CookieFilterMiddleware(get_response=get_response)
+
+        allowed_cookies = middleware.allowed_cookies
+
+        self.assertSetEqual(
+            allowed_cookies, {"csrftoken", "django_language", "sessionid", "messages"}
+        )
+
+    @override_settings(COOKIEFILTER_ALLOWED_NAMES=["analytics", "sessionid"])
+    def test_custom_allowed_cookies(self):
+        middleware = CookieFilterMiddleware(get_response=get_response)
+
+        allowed_cookies = middleware.allowed_cookies
+
+        self.assertSetEqual(allowed_cookies, {"analytics", "sessionid"})
+
+    @override_settings(COOKIEFILTER_ALLOWED=["legacy"])
+    def test_deprecated_allowed_setting(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            middleware = CookieFilterMiddleware(get_response=get_response)
+
+            allowed_cookies = middleware.allowed_cookies
+
+            self.assertSetEqual(allowed_cookies, {"legacy"})
+            self.assertTrue(len(w), 1)
+            deprecation_warning = w[0]
+            self.assertEqual(deprecation_warning.category, DeprecationWarning)
+            self.assertEqual(
+                deprecation_warning.message.args,
+                ("COOKIEFILTER_ALLOWED is deprecated, use COOKIEFILTER_ALLOWED_NAMES instead",),
+            )
+
     def test_standard_cookies(self):
         middleware = CookieFilterMiddleware(get_response=get_response)
         request = RequestFactory().get("/")


### PR DESCRIPTION
In a following PR I'm going to add support for `COOKIEFILTER_ALLOWED_PATTERNS`, which will be a list of regular expressions that are allowed in addition to cookie names.

So for clarity, I'm renaming this old setting.

Plan is for a version 1.3 with this new feature, and in the future version 2 will remove support for the old setting.