### PR TITLE
Add COOKIEFILTER_ALLOWED_PATTERNS for filtering cookie names with regular expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,12 @@ COOKIEFILTER_ALLOWED_NAMES = [
 > [!NOTE]
 > This setting was previously named ``COOKIEFILTER_ALLOWED``, which is now deprecated and will be
 > removed in a future version.
+
+Or if you need to allow multiple cookies that don't have specific names, you can add
+``COOKIEFILTER_ALLOWED_PATTERNS`` to allow additional cookie names with regular expressions:
+
+```python
+COOKIEFILTER_ALLOWED_PATTERNS = [
+    r"^abtesting-\d+-version$",
+]
+```

--- a/cookiefilter/middleware.py
+++ b/cookiefilter/middleware.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import warnings
 from functools import lru_cache
 from http.cookies import SimpleCookie
@@ -38,6 +39,14 @@ class CookieFilterMiddleware:
 
         return frozenset(getattr(settings, "COOKIEFILTER_ALLOWED_NAMES", default_cookies))
 
+    @classproperty
+    @lru_cache(maxsize=1)
+    def allowed_patterns(cls):
+        return tuple(
+            re.compile(pattern)
+            for pattern in getattr(settings, "COOKIEFILTER_ALLOWED_PATTERNS", [])
+        )
+
     def __init__(self, get_response):
         self.get_response = get_response
 
@@ -46,10 +55,19 @@ class CookieFilterMiddleware:
         current_cookies = set(request.COOKIES.keys())
         unwanted_cookies = current_cookies.difference(self.allowed_cookies)
 
+        # Then we filter the unwanted list with allowed_patterns, for scenarios where multiple
+        # cookies are set
+        if unwanted_cookies and self.allowed_patterns:
+            unwanted_cookies = {
+                key
+                for key in unwanted_cookies
+                if not any(pattern.fullmatch(key) for pattern in self.allowed_patterns)
+            }
+
         if unwanted_cookies:
             # There are some unwanted cookies, so we create a new COOKIES dict containing only the
             # cookies we want
-            wanted_cookies = current_cookies.intersection(self.allowed_cookies)
+            wanted_cookies = current_cookies - unwanted_cookies
 
             logger.debug("Deleted %d cookie(s)", len(unwanted_cookies))
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,3 +1,4 @@
+import re
 import warnings
 
 from django.http import HttpResponse
@@ -15,23 +16,31 @@ class TestCookieFilterMiddleware(SimpleTestCase):
     def setUp(self):
         # Ensure lru_cache is cleared before each run
         CookieFilterMiddleware.__dict__["allowed_cookies"].fget.cache_clear()
+        CookieFilterMiddleware.__dict__["allowed_patterns"].fget.cache_clear()
 
     def test_default_allowed_cookies(self):
         middleware = CookieFilterMiddleware(get_response=get_response)
 
         allowed_cookies = middleware.allowed_cookies
+        allowed_patterns = middleware.allowed_patterns
 
         self.assertSetEqual(
             allowed_cookies, {"csrftoken", "django_language", "sessionid", "messages"}
         )
+        self.assertTupleEqual(allowed_patterns, ())
 
-    @override_settings(COOKIEFILTER_ALLOWED_NAMES=["analytics", "sessionid"])
+    @override_settings(
+        COOKIEFILTER_ALLOWED_NAMES=["analytics", "sessionid"],
+        COOKIEFILTER_ALLOWED_PATTERNS=[r"^abtesting-\d+-version$"],
+    )
     def test_custom_allowed_cookies(self):
         middleware = CookieFilterMiddleware(get_response=get_response)
 
         allowed_cookies = middleware.allowed_cookies
+        allowed_patterns = middleware.allowed_patterns
 
         self.assertSetEqual(allowed_cookies, {"analytics", "sessionid"})
+        self.assertTupleEqual(allowed_patterns, (re.compile(r"^abtesting-\d+-version$"),))
 
     @override_settings(COOKIEFILTER_ALLOWED=["legacy"])
     def test_deprecated_allowed_setting(self):
@@ -84,3 +93,26 @@ class TestCookieFilterMiddleware(SimpleTestCase):
 
         self.assertEqual(request.COOKIES, {})
         self.assertNotIn("HTTP_COOKIE", request.META)
+
+    @override_settings(
+        COOKIEFILTER_ALLOWED_PATTERNS=[r"^abtesting-\d+-version$"],
+    )
+    def test_regex_cookie_kept(self):
+        middleware = CookieFilterMiddleware(get_response=get_response)
+        request = RequestFactory().get("/")
+        request.COOKIES = {
+            "analytics": "removed",
+            "csrftoken": "token",
+            "abtesting-1-version": "control",
+            "abtesting-2-version": "control",
+            "abtesting-3-version-fake": "unused",
+        }
+        request.META = {"HTTP_COOKIE": ""}
+
+        middleware(request=request)
+
+        self.assertIn("csrftoken", request.COOKIES)
+        self.assertIn("abtesting-1-version", request.COOKIES)
+        self.assertIn("abtesting-2-version", request.COOKIES)
+        self.assertNotIn("abtesting-3-version-fake", request.COOKIES)
+        self.assertNotIn("analytics", request.COOKIES)


### PR DESCRIPTION
At some point on one of our projects we'll want to install wagtail-ab-testing, however that sets a cookie name that has the pattern `wagtail-ab-testing_{version_id}_version`.

So this PR adds support for filtering cookie names by regular expressions.